### PR TITLE
fix: 修复商机导入货源时标题超长导致 name 列写入失败

### DIFF
--- a/src/main/java/com/xianyusmart/service/MerchantOperationsService.java
+++ b/src/main/java/com/xianyusmart/service/MerchantOperationsService.java
@@ -134,8 +134,8 @@ public class MerchantOperationsService {
         if (request.getName() == null || request.getName().isBlank()) {
             throw new IllegalArgumentException("资源名称不能为空");
         }
-        if (request.getName().trim().length() > 200) {
-            throw new IllegalArgumentException("资源名称不能超过200个字符");
+        if (request.getName().trim().length() > 512) {
+            throw new IllegalArgumentException("资源名称不能超过512个字符");
         }
         validateOwnedAccount(request.getXianyuAccountId());
         if ("WORKFLOW".equals(request.getResourceType())) {
@@ -320,7 +320,7 @@ public class MerchantOperationsService {
             if (existing == null) {
                 supply = createSupply(candidate, accountId);
             } else {
-                existing.setName(text(candidate.get("title")));
+                existing.setName(limitName(text(candidate.get("title"))));
                 existing.setDataJson(writeJson(candidate));
                 resourceMapper.updateById(existing);
                 supply = existing;
@@ -653,7 +653,7 @@ public class MerchantOperationsService {
                 MerchantResource supply = new MerchantResource();
                 supply.setTenantId(task.getTenantId());
                 supply.setResourceType("SUPPLY");
-                supply.setName(text(candidate.get("title")));
+                supply.setName(limitName(text(candidate.get("title"))));
                 supply.setStatus(1);
                 supply.setXianyuAccountId(rule.getXianyuAccountId());
                 supply.setXyGoodsId(itemId);
@@ -825,7 +825,7 @@ public class MerchantOperationsService {
         if (!sourceUrl.isBlank()) {
             Map<String, Object> collected = platformPublishService.collect(sourceUrl, supply.getXianyuAccountId());
             data.putAll(collected);
-            supply.setName(text(collected.get("title")));
+            supply.setName(limitName(text(collected.get("title"))));
             String itemId = text(collected.get("itemId"));
             if (!itemId.isBlank()) {
                 supply.setXyGoodsId(itemId);
@@ -850,7 +850,7 @@ public class MerchantOperationsService {
         data.put("description", item.getDetailInfo());
         data.put("images", collectImages(item));
         data.put("detailUrl", item.getDetailUrl());
-        supply.setName(item.getTitle());
+        supply.setName(limitName(item.getTitle() == null ? "" : item.getTitle().trim()));
         supply.setDataJson(writeJson(data));
         if (item.getSoldPrice() != null) {
             supply.setAmount(decimalValue(item.getSoldPrice(), supply.getAmount()));
@@ -990,7 +990,7 @@ public class MerchantOperationsService {
         MerchantResource supply = new MerchantResource();
         supply.setTenantId(requireTenantId());
         supply.setResourceType("SUPPLY");
-        supply.setName(text(candidate.get("title")).isBlank() ? "待完善货源" : text(candidate.get("title")));
+        supply.setName(limitName(text(candidate.get("title"))).isBlank() ? "待完善货源" : limitName(text(candidate.get("title"))));
         supply.setStatus(1);
         supply.setXianyuAccountId(accountId);
         supply.setXyGoodsId(blankToNull(text(candidate.get("itemId"))));
@@ -1159,6 +1159,13 @@ public class MerchantOperationsService {
 
     private String text(Object value) {
         return value == null ? "" : String.valueOf(value).trim();
+    }
+
+    /**
+     * merchant_resource.name 上限 512 字符，外部平台返回的商品标题可能超长，入库前统一截断。
+     */
+    private String limitName(String value) {
+        return value.length() > 512 ? value.substring(0, 512) : value;
     }
 
     private int intValue(Object value, int defaultValue) {

--- a/src/main/resources/db/migration/V15__widen_merchant_resource_name.sql
+++ b/src/main/resources/db/migration/V15__widen_merchant_resource_name.sql
@@ -1,0 +1,4 @@
+-- 闲鱼商品标题（尤其是详情接口返回的完整标题）可能超过 200 字符，
+-- 商机导入货源时触发 MysqlDataTruncation: Data too long for column 'name'。
+-- 加宽 merchant_resource.name，代码侧同步做截断保护。
+ALTER TABLE merchant_resource MODIFY COLUMN name VARCHAR(512) NOT NULL;


### PR DESCRIPTION
## 问题

商机发掘页点击「下一步：整理商品」导入候选商品时报错：

```
com.mysql.cj.jdbc.exceptions.MysqlDataTruncation:
Data truncation: Data too long for column 'name' at row 1
### SQL: INSERT INTO merchant_resource (tenant_id, resource_type, name, ...)
```

**根因**：`merchant_resource.name` 在 V3 迁移中定义为 `VARCHAR(200)`，而闲鱼商品的完整标题可能超过 200 字符。手工创建资源的入口（`saveResource`）有长度校验，但商机导入入口 `createSupply` 等直接写入平台返回的标题，没有任何长度保护。

## 修复

- **新增 V15 迁移**：`ALTER TABLE merchant_resource MODIFY COLUMN name VARCHAR(512) NOT NULL`
- **新增 `limitName()` 截断保护**（上限 512），应用到全部 5 处接收外部平台标题的入库入口：
  - `importOpportunities` 新增分支（`createSupply`）与更新分支
  - `executeSelection` 选品采集
  - `executeCollect` 采集任务两个分支
- 手工创建资源的长度校验上限同步从 200 调整为 512，与表结构保持一致

## 验证

- `mvn compile` 通过
- 已在本地运行环境执行 ALTER 验证导入恢复成功