### PR TITLE
fix: preserve used kami history on deletion

### DIFF
--- a/src/main/java/com/xianyusmart/mapper/XianyuGoodsOrderMapper.java
+++ b/src/main/java/com/xianyusmart/mapper/XianyuGoodsOrderMapper.java
@@ -274,10 +274,9 @@ public interface XianyuGoodsOrderMapper {
             "delivery_message_next_retry_time = NULL, lease_owner = NULL, lease_expire_time = NULL, " +
             "exception_revision = exception_revision + 1 " +
             "WHERE delivery_message_state = 3 AND delivery_message_next_retry_time <= NOW(3) " +
-            "AND NOT EXISTS (SELECT 1 FROM xianyu_kami_usage_record r JOIN xianyu_kami_item i " +
-            "ON i.id = r.kami_item_id WHERE r.xianyu_account_id = xianyu_goods_order.xianyu_account_id " +
-            "AND r.order_id = xianyu_goods_order.order_id AND r.delivery_status = 'DELIVERED' " +
-            "AND i.order_id = xianyu_goods_order.order_id AND i.status = 1) LIMIT #{limit}")
+            "AND NOT EXISTS (SELECT 1 FROM xianyu_kami_usage_record r " +
+            "WHERE r.xianyu_account_id = xianyu_goods_order.xianyu_account_id " +
+            "AND r.order_id = xianyu_goods_order.order_id AND r.delivery_status = 'DELIVERED') LIMIT #{limit}")
     int markStaleCardHeldMessagesReviewRequired(@Param("limit") int limit);
 
     @Update("UPDATE xianyu_goods_order SET delivery_message_state = 1, delivery_message_next_retry_time = NULL WHERE id = #{id}")
@@ -301,9 +300,8 @@ public interface XianyuGoodsOrderMapper {
 
     @Select("SELECT o.* FROM xianyu_goods_order o WHERE o.delivery_message_content IS NOT NULL AND (" +
             "(o.delivery_message_state = 3 AND EXISTS (SELECT 1 FROM xianyu_kami_usage_record r " +
-            "JOIN xianyu_kami_item i ON i.id = r.kami_item_id WHERE r.xianyu_account_id = o.xianyu_account_id " +
-            "AND r.order_id = o.order_id AND r.delivery_status = 'DELIVERED' " +
-            "AND i.order_id = o.order_id AND i.status = 1)) OR " +
+            "WHERE r.xianyu_account_id = o.xianyu_account_id " +
+            "AND r.order_id = o.order_id AND r.delivery_status = 'DELIVERED')) OR " +
             "o.delivery_message_state = 5) " +
             "ORDER BY o.create_time ASC LIMIT #{limit}")
     List<XianyuGoodsOrder> selectCommittedHeldDeliveryMessages(@Param("limit") int limit);

--- a/src/main/resources/db/migration/V17__preserve_kami_usage_history.sql
+++ b/src/main/resources/db/migration/V17__preserve_kami_usage_history.sql
@@ -1,0 +1,6 @@
+-- 使用记录保存完整交付快照，删除库存卡密时只解除关联并保留历史审计。
+ALTER TABLE xianyu_kami_usage_record
+    DROP FOREIGN KEY fk_usage_item,
+    MODIFY COLUMN kami_item_id BIGINT NULL,
+    ADD CONSTRAINT fk_usage_item_history FOREIGN KEY (kami_item_id)
+        REFERENCES xianyu_kami_item (id) ON DELETE SET NULL;


### PR DESCRIPTION
## 修改内容
- 新增 V17 迁移，删除卡密库存项时将使用记录关联置空并保留历史快照
- 订单交付判断改为直接依赖已交付使用记录，不再依赖已删除或重置的库存项
- 使用单条 MySQL 5.7 ALTER TABLE，避免半迁移状态

## 验证
- Java 21 项目测试通过
- 隔离 MySQL 5.7 已复现旧外键异常
- 执行正式 V17 后卡密删除成功，使用记录、订单号、卡密快照和交付状态保持完整
- 独立代码复审无 Critical、Important 或 Minor 问题

Closes #11