### PR TITLE
fix: 修复仅私聊发货未确认平台订单

### DIFF
--- a/src/main/java/com/xianyusmart/event/DeliveryMessageSentEvent.java
+++ b/src/main/java/com/xianyusmart/event/DeliveryMessageSentEvent.java
@@ -1,0 +1,9 @@
+package com.xianyusmart.event;
+
+import com.xianyusmart.entity.XianyuGoodsOrder;
+
+/**
+ * 发货私聊实际发送成功事件
+ */
+public record DeliveryMessageSentEvent(XianyuGoodsOrder order) {
+}

--- a/src/main/java/com/xianyusmart/service/BuyerMessageService.java
+++ b/src/main/java/com/xianyusmart/service/BuyerMessageService.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xianyusmart.context.TenantContext;
 import com.xianyusmart.entity.XianyuGoodsAutoDeliveryConfig;
 import com.xianyusmart.entity.XianyuGoodsOrder;
+import com.xianyusmart.event.DeliveryMessageSentEvent;
 import com.xianyusmart.mapper.XianyuGoodsOrderMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -29,15 +31,18 @@ public class BuyerMessageService {
     private final SentMessageSaveService sentMessageSaveService;
     private final XianyuGoodsOrderMapper orderMapper;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     public BuyerMessageService(WebSocketService webSocketService,
                                SentMessageSaveService sentMessageSaveService,
                                XianyuGoodsOrderMapper orderMapper,
-                               ObjectMapper objectMapper) {
+                               ObjectMapper objectMapper,
+                               ApplicationEventPublisher eventPublisher) {
         this.webSocketService = webSocketService;
         this.sentMessageSaveService = sentMessageSaveService;
         this.orderMapper = orderMapper;
         this.objectMapper = objectMapper;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -248,6 +253,9 @@ public class BuyerMessageService {
         boolean success = sendMessage(order, message);
         if (success) {
             orderMapper.markDeliveryMessageSent(order.getId());
+            order.setDeliveryMessageState(1);
+            // 立即发送和重试发送共用成功事件，保证后续平台确认不会遗漏。
+            eventPublisher.publishEvent(new DeliveryMessageSentEvent(order));
             return true;
         }
         deferDeliveryMessage(order);

--- a/src/main/java/com/xianyusmart/service/impl/AutoDeliveryServiceImpl.java
+++ b/src/main/java/com/xianyusmart/service/impl/AutoDeliveryServiceImpl.java
@@ -5,6 +5,7 @@ import com.xianyusmart.entity.XianyuGoodsOrder;
 import com.xianyusmart.entity.XianyuGoodsAutoReplyRecord;
 import com.xianyusmart.entity.XianyuGoodsConfig;
 import com.xianyusmart.enums.DeliveryStatus;
+import com.xianyusmart.event.DeliveryMessageSentEvent;
 import com.xianyusmart.mapper.XianyuGoodsAutoDeliveryConfigMapper;
 import com.xianyusmart.mapper.XianyuGoodsConfigMapper;
 import com.xianyusmart.mapper.XianyuGoodsOrderMapper;
@@ -27,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -681,6 +683,29 @@ public class AutoDeliveryServiceImpl implements AutoDeliveryService {
             } catch (Exception e) {
                 log.error("【账号{}】自动发货图片[{}/{}]发送异常: xyGoodsId={}", accountId, i + 1, imageUrls.length, xyGoodsId, e);
             }
+        }
+    }
+
+    @EventListener
+    public void handleDeliveryMessageSent(DeliveryMessageSentEvent event) {
+        XianyuGoodsOrder order = event == null ? null : event.order();
+        if (order == null || order.getXianyuAccountId() == null || order.getXyGoodsId() == null
+                || order.getOrderId() == null || Integer.valueOf(1).equals(order.getConfirmState())) {
+            return;
+        }
+        try {
+            XianyuGoodsAutoDeliveryConfig config = resolveDeliveryConfig(
+                    order.getXianyuAccountId(), order.getXyGoodsId(), order.getSkuId());
+            if (config == null || !Integer.valueOf(0).equals(config.getVoucherDeliveryEnabled())
+                    || Integer.valueOf(0).equals(config.getChatDeliveryEnabled())
+                    || !Integer.valueOf(1).equals(config.getAutoConfirmShipment())) {
+                return;
+            }
+            // 私聊独立交付成功后再确认平台订单，避免卡密未送达时提前标记发货。
+            executeAutoConfirmShipment(order.getXianyuAccountId(), order.getOrderId());
+        } catch (Exception e) {
+            log.error("【账号{}】私聊交付后自动确认发货异常: orderId={}",
+                    order.getXianyuAccountId(), order.getOrderId(), e);
         }
     }
 


### PR DESCRIPTION
## 问题

关闭发货凭证、仅开启买家私聊时，卡密能够发送，但平台订单仍停留在待发货。

## 修复

- 在私聊实际发送成功的统一出口发布交付成功事件，立即发送和重试发送共用
- 仅在凭证关闭、私聊开启且自动确认开启时调用现有平台确认发货逻辑
- 复用现有多 SKU 配置解析和平台确认方法，凭证链路保持不变

## 验证

- 临时回归测试覆盖私聊发送成功、仅私聊确认、凭证开启不重复确认，验证后已清理
- `mvn clean test`
- `mvn -DskipTests package`

Fixes #27